### PR TITLE
Resolves: rhbz#1352097 - Unitfile does not depend on docker

### DIFF
--- a/systemd/rhel-push-plugin.service
+++ b/systemd/rhel-push-plugin.service
@@ -1,9 +1,8 @@
 [Unit]
 Description=Docker Block RHEL push plugin authZ Plugin
 Documentation=man:rhel-push-plugin(8)
-Before=docker.service
 After=network.target rhel-push-plugin.socket
-Requires=rhel-push-plugin.socket docker.service
+Requires=rhel-push-plugin.socket
 
 [Service]
 # might need to set flags...


### PR DESCRIPTION
We should let the docker unitfiles start after rhel-push-plugin and not
specify the other way around.
This allows rhel-push-plugin to be independent of
docker / docker-latest unitfiles which helps in the case of simultaneous
multi-docker installs.

So, the accompanying change in docker / docker-latest unitfiles would be:
-After=network.target
+After=network.target rhel-push-plugin.socket

Signed-off-by: Lokesh Mandvekar lsm5@redhat.com
